### PR TITLE
fix: 핸드폰 인증안했을때, 가입약관 동의 안했을때 안내창 띄우기

### DIFF
--- a/public/js/validation.js
+++ b/public/js/validation.js
@@ -5,6 +5,7 @@ const inputEmailId = document.getElementById('email-id');
 const inputEmailSite = document.getElementById('email-site');
 const inputName = document.getElementById('name');
 const inputPhone = document.getElementById('phone');
+const inputAgreement = document.getElementById('essential-terms');
 
 const errorId = document.getElementById('error-id');
 const errorPassword = document.getElementById('error-password');
@@ -289,8 +290,15 @@ function handleFormSubmit() {
     validateInput(inputText);
   });
   const errorInputs = document.getElementsByClassName('error-input');
+  console.log(inputAgreement.checked);
   if (errorInputs.length > 0) {
     errorInputs[0].focus();
+    return false;
+  } else if (verifyBtn.textContent !== '인증완료') {
+    alert('핸드폰 인증을 완료해주세요.');
+    return false;
+  } else if (!inputAgreement.checked) {
+    alert('약관 필수항목에 동의해주세요.');
     return false;
   } else {
     return true;


### PR DESCRIPTION
## 체크리스트

- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈

- resolved #12 

## 설명

핸드폰 인증안했을때, 가입약관 동의 안했을때 alert를 이용하여 안내창 띄우기